### PR TITLE
pkgs: pin pnpm to stabilize client dependency hashes

### DIFF
--- a/pkgs/equicord.nix
+++ b/pkgs/equicord.nix
@@ -4,7 +4,7 @@
   fetchPnpmDeps,
   buildWebExtension ? false,
   bun,
-  pnpm_11,
+  callPackage,
   writeShellApplication,
   cacert,
   curl,
@@ -17,7 +17,7 @@ let
   version = "1.15.4.0-2026-09-03";
   rev = "b90a13be8e0636837e9bfdc8f18cc40cf8190962";
   hash = "sha256-Bu1226PDuCmY8w7RKTMZJzsLQiF0URuABZGxgo78H7k=";
-  pnpmDepsHash = "sha256-VW4VKmM/12wl0sMFB9hG9K+sXjYVxlafu14IplGL/sw=";
+  pnpmDepsHash = "sha256-hBZHHB5kRkNqep5vWMMnwIblNCAOZvLotDjJUJd9iMU=";
   inherit (equicord.src) owner repo;
   src = fetchFromGitHub {
     inherit
@@ -59,7 +59,7 @@ in
 (equicord.override { inherit buildWebExtension; }).overrideAttrs (
   oldAttrs:
   let
-    pnpm = pnpm_11;
+    pnpm = callPackage ./pnpm.nix { };
     patches = (oldAttrs.patches or [ ]) ++ [
       ./patches/equicord-content-warning-settings.patch
     ];

--- a/pkgs/pnpm.nix
+++ b/pkgs/pnpm.nix
@@ -1,0 +1,9 @@
+{ pnpm_11 }:
+
+# pnpm changes its store metadata between minor releases. Keep dependency
+# fetching and offline builds on the same version across Nixpkgs inputs.
+# Regenerate both clients' pnpmDepsHash values when updating this version.
+pnpm_11.override {
+  version = "11.25.0";
+  hash = "sha256-M90HSPJ+eRbE8ci2lDRhmD40U7BrvaYxKmKAEwtIgeU=";
+}

--- a/pkgs/vencord.nix
+++ b/pkgs/vencord.nix
@@ -4,7 +4,7 @@
   vencord,
   buildWebExtension ? false,
   bun,
-  pnpm_11,
+  callPackage,
   writeShellApplication,
   cacert,
   curl,
@@ -17,7 +17,7 @@ let
   version = "1.15.4-2026-08-30";
   rev = "0e40e433d7aa9168f656aba733d01e761b7ca8ca";
   hash = "sha256-IoyxQuFrTlpwTqYgqsbeoLMuw8Hh7IJlvQi7ULdNAR0=";
-  pnpmDepsHash = "sha256-Zn6No8EyGHUR36Av1VxGWD19tUMBxSUo3QPCPXzlx0U=";
+  pnpmDepsHash = "sha256-LiAcWwGmZlpO+rr0tcMNpViBiBRhSHj+wvyHFIe32lw=";
   src = fetchFromGitHub {
     inherit (vencord.src) owner repo;
     inherit rev hash;
@@ -26,7 +26,7 @@ in
 (vencord.override { inherit buildWebExtension; }).overrideAttrs (
   oldAttrs:
   let
-    pnpm = pnpm_11;
+    pnpm = callPackage ./pnpm.nix { };
     patches = [ ];
     postPatch = "";
   in


### PR DESCRIPTION
Equicord's dependency hash changes between pnpm 11.20.0 and 11.25.0 because
newer pnpm adds `requiresPrepare` metadata for Git dependencies. Since Nixcord
uses the caller's package set by default, the same source fails to build with
some Nixpkgs revisions. Replacing the hash alone breaks our pinned package set.

Pin pnpm 11.25.0 for both dependency fetching and offline builds, and regenerate
the Equicord and Vencord dependency hashes.

Verified full builds of both clients on x86_64-linux with our pinned Nixpkgs and
the reporter's unstable revision (`801bef6abd86b91e51083066b83fb354a11fc640`),
and on aarch64-darwin. Existing configuration, assertion, and non-flake checks
and Nix formatting pass.
